### PR TITLE
Add merchant-referring-name fields to an order

### DIFF
--- a/src/Gateway/DataSets/DataSet.php
+++ b/src/Gateway/DataSets/DataSet.php
@@ -52,6 +52,7 @@ abstract class DataSet
     const GENERAL_DATA_ORDER_DATA_ORDER_META = 'data.general-data.order-data.order-meta';
     const GENERAL_DATA_ORDER_DATA_MERCHANT_SIDE_URL = 'data.general-data.order-data.merchant-side-url';
     const GENERAL_DATA_ORDER_DATA_RECIPIENT_NAME = 'data.general-data.order-data.recipient-name';
+    const GENERAL_DATA_ORDER_DATA_MERCHANT_REFERRING_NAME = 'data.general-data.order-data.merchant-referring-name';
 
     // payment data
     const PAYMENT_METHOD_DATA_PAN = 'data.payment-method-data.pan';

--- a/src/Gateway/DataSets/Order.php
+++ b/src/Gateway/DataSets/Order.php
@@ -98,4 +98,15 @@ class Order extends DataSet implements DataSetInterface
 
         return $this;
     }
+
+    /**
+     * @param  string $merchantReferringName
+     * @return Order
+     */
+    public function setMerchantReferringName(string $merchantReferringName): self
+    {
+        $this->data[self::GENERAL_DATA_ORDER_DATA_MERCHANT_REFERRING_NAME] = $merchantReferringName;
+
+        return $this;
+    }
 }

--- a/src/Gateway/Validator/Validator.php
+++ b/src/Gateway/Validator/Validator.php
@@ -62,6 +62,7 @@ class Validator
         DataSet::GENERAL_DATA_ORDER_DATA_ORDER_META => 'array',
         DataSet::GENERAL_DATA_ORDER_DATA_MERCHANT_SIDE_URL => 'string',
         DataSet::GENERAL_DATA_ORDER_DATA_RECIPIENT_NAME => 'string',
+        DataSet::GENERAL_DATA_ORDER_DATA_MERCHANT_REFERRING_NAME => 'string',
 
         // payment data
         DataSet::PAYMENT_METHOD_DATA_PAN => 'string',

--- a/tests/Gateway/DataSets/OrderTest.php
+++ b/tests/Gateway/DataSets/OrderTest.php
@@ -24,6 +24,7 @@ class OrderTest extends TestCase
             DataSet::GENERAL_DATA_ORDER_DATA_MERCHANT_USER_ID => 'ccc',
             DataSet::GENERAL_DATA_ORDER_DATA_ORDER_META => ['foo'],
             DataSet::GENERAL_DATA_ORDER_DATA_RECIPIENT_NAME => 'qqq',
+            DataSet::GENERAL_DATA_ORDER_DATA_MERCHANT_REFERRING_NAME => 'www',
         ];
 
         $order = new Order();
@@ -33,6 +34,7 @@ class OrderTest extends TestCase
             ->setMerchantUserID('ccc')
             ->setMeta(['foo'])
             ->setRecipientName('qqq')
+            ->setMerchantReferringName('www')
             ->getRaw();
 
         $this->assertEquals($expected, $raw);


### PR DESCRIPTION
GW3-4496 Add merchant-referring-name fields to an order. Is required for dynamic descriptor.