### PR TITLE
Added support for external 3-D Secure

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:

--- a/src/Gateway/DataSets/DataSet.php
+++ b/src/Gateway/DataSets/DataSet.php
@@ -68,6 +68,11 @@ abstract class DataSet
     const PAYMENT_METHOD_DATA_CVV = 'data.payment-method-data.cvv';
     const PAYMENT_METHOD_DATA_CARDHOLDER_NAME = 'data.payment-method-data.cardholder-name';
     const PAYMENT_METHOD_DATA_EXTERNAL_MPI_DATA = 'data.payment-method-data.external-mpi-data';
+    const PAYMENT_METHOD_DATA_EXTERNAL_MPI_PROTOCOL = 'data.payment-method-data.external-mpi-data.protocolVersion';
+    const PAYMENT_METHOD_DATA_EXTERNAL_MPI_DS_TRANS_ID = 'data.payment-method-data.external-mpi-data.dsTransID';
+    const PAYMENT_METHOD_DATA_EXTERNAL_MPI_XID = 'data.payment-method-data.external-mpi-data.xid';
+    const PAYMENT_METHOD_DATA_EXTERNAL_MPI_CAVV = 'data.payment-method-data.external-mpi-data.cavv';
+    const PAYMENT_METHOD_DATA_EXTERNAL_MPI_TRANS_STATUS = 'data.payment-method-data.external-mpi-data.transStatus';
 
     // money data
     const MONEY_DATA_AMOUNT = 'data.money-data.amount';

--- a/src/Gateway/DataSets/PaymentMethod.php
+++ b/src/Gateway/DataSets/PaymentMethod.php
@@ -63,4 +63,59 @@ class PaymentMethod extends DataSet implements DataSetInterface
 
         return $this;
     }
+
+    /**
+     * @param  string        $protocolVersion
+     * @return PaymentMethod
+     */
+    public function setExternalMpiProtocolVersion(string $protocolVersion): self
+    {
+        $this->data[self::PAYMENT_METHOD_DATA_EXTERNAL_MPI_PROTOCOL] = $protocolVersion;
+
+        return $this;
+    }
+
+    /**
+     * @param  string        $dsTransID
+     * @return PaymentMethod
+     */
+    public function setExternalMpiDsTransID(string $dsTransID): self
+    {
+        $this->data[self::PAYMENT_METHOD_DATA_EXTERNAL_MPI_DS_TRANS_ID] = $dsTransID;
+
+        return $this;
+    }
+
+    /**
+     * @param  string        $xid
+     * @return PaymentMethod
+     */
+    public function setExternalMpiXID(string $xid): self
+    {
+        $this->data[self::PAYMENT_METHOD_DATA_EXTERNAL_MPI_XID] = $xid;
+
+        return $this;
+    }
+
+    /**
+     * @param  string        $cavv
+     * @return PaymentMethod
+     */
+    public function setExternalMpiCAVV(string $cavv): self
+    {
+        $this->data[self::PAYMENT_METHOD_DATA_EXTERNAL_MPI_CAVV] = $cavv;
+
+        return $this;
+    }
+
+    /**
+     * @param  string        $transStatus
+     * @return PaymentMethod
+     */
+    public function setExternalMpiTransStatus(string $transStatus): self
+    {
+        $this->data[self::PAYMENT_METHOD_DATA_EXTERNAL_MPI_TRANS_STATUS] = $transStatus;
+
+        return $this;
+    }
 }

--- a/src/Gateway/Validator/Validator.php
+++ b/src/Gateway/Validator/Validator.php
@@ -77,6 +77,11 @@ class Validator
         DataSet::PAYMENT_METHOD_DATA_CVV => 'string',
         DataSet::PAYMENT_METHOD_DATA_CARDHOLDER_NAME => 'string',
         DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_DATA => 'string',
+        DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_PROTOCOL => 'string',
+        DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_DS_TRANS_ID => 'string',
+        DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_XID => 'string',
+        DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_CAVV => 'string',
+        DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_TRANS_STATUS => 'string',
 
         // money data
         DataSet::MONEY_DATA_AMOUNT => 'integer',

--- a/tests/Gateway/DataSets/PaymentMethodTest.php
+++ b/tests/Gateway/DataSets/PaymentMethodTest.php
@@ -22,6 +22,11 @@ class PaymentMethodTest extends TestCase
             DataSet::PAYMENT_METHOD_DATA_CVV => '123',
             DataSet::PAYMENT_METHOD_DATA_EXPIRE => '12/21',
             DataSet::PAYMENT_METHOD_DATA_CARDHOLDER_NAME => 'John Doe',
+            DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_PROTOCOL => '2.2.0',
+            DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_DS_TRANS_ID => '26221368-1c3d-4f3c-ba34-2efb76644c32',
+            DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_XID => 'b+f8duAy8jNTQ0DB4U3mSmPyp8s=',
+            DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_CAVV => 'kBMI/uGZvlKCygBkcQIlLJeBTPLG',
+            DataSet::PAYMENT_METHOD_DATA_EXTERNAL_MPI_TRANS_STATUS => 'Y',
         ];
 
         $paymentMethod = new PaymentMethod();
@@ -30,6 +35,11 @@ class PaymentMethodTest extends TestCase
             ->setCVV('123')
             ->setExpire('12/21')
             ->setCardHolderName('John Doe')
+            ->setExternalMpiProtocolVersion('2.2.0')
+            ->setExternalMpiDsTransID('26221368-1c3d-4f3c-ba34-2efb76644c32')
+            ->setExternalMpiXID('b+f8duAy8jNTQ0DB4U3mSmPyp8s=')
+            ->setExternalMpiCAVV('kBMI/uGZvlKCygBkcQIlLJeBTPLG')
+            ->setExternalMpiTransStatus('Y')
             ->getRaw();
 
         $this->assertEquals($expected, $raw);


### PR DESCRIPTION
Added methods for PaymentMethod object (when 3-D Secure was completed before the Gateway call):
 - setExternalMpiProtocolVersion
 - setExternalMpiDsTransID
 - setExternalMpiXID
 - setExternalMpiCAVV
 - setExternalMpiTransStatus