### PR TITLE
Added new fields for order data to satisfy AN5524 requirements:

### DIFF
--- a/src/Gateway/DataSets/DataSet.php
+++ b/src/Gateway/DataSets/DataSet.php
@@ -61,6 +61,8 @@ abstract class DataSet
     const GENERAL_DATA_ORDER_DATA_CUSTOM_RETURN_URL = 'data.general-data.order-data.custom-return-url';
     const GENERAL_DATA_ORDER_DATA_RECURRING_EXPIRY = 'data.general-data.order-data.recurring-expiry';
     const GENERAL_DATA_ORDER_DATA_RECURRING_FREQUENCY = 'data.general-data.order-data.recurring-frequency';
+    const GENERAL_DATA_ORDER_DATA_MITS_EXPECTED = 'data.general-data.order-data.mits-expected';
+    const GENERAL_DATA_ORDER_DATA_VARIABLE_AMOUNT_RECURRING = 'data.general-data.order-data.variable-amount-recurring';
 
     // payment data
     const PAYMENT_METHOD_DATA_PAN = 'data.payment-method-data.pan';

--- a/src/Gateway/DataSets/Order.php
+++ b/src/Gateway/DataSets/Order.php
@@ -157,4 +157,28 @@ class Order extends DataSet implements DataSetInterface
 
         return $this;
     }
+
+    /**
+     * @param bool $value (default: true)
+     *
+     * @return Order
+     */
+    public function setMitsExpected(bool $value = true): self
+    {
+        $this->data[ self::GENERAL_DATA_ORDER_DATA_MITS_EXPECTED ] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param bool $value (default: true)
+     *
+     * @return Order
+     */
+    public function setVariableAmountRecurring(bool $value = true): self
+    {
+        $this->data[ self::GENERAL_DATA_ORDER_DATA_VARIABLE_AMOUNT_RECURRING ] = $value;
+
+        return $this;
+    }
 }

--- a/src/Gateway/Validator/Validator.php
+++ b/src/Gateway/Validator/Validator.php
@@ -70,6 +70,8 @@ class Validator
         DataSet::GENERAL_DATA_ORDER_DATA_CUSTOM_RETURN_URL => 'string',
         DataSet::GENERAL_DATA_ORDER_DATA_RECURRING_EXPIRY => 'string',
         DataSet::GENERAL_DATA_ORDER_DATA_RECURRING_FREQUENCY => 'string',
+        DataSet::GENERAL_DATA_ORDER_DATA_MITS_EXPECTED => 'boolean',
+        DataSet::GENERAL_DATA_ORDER_DATA_VARIABLE_AMOUNT_RECURRING => 'boolean',
 
         // payment data
         DataSet::PAYMENT_METHOD_DATA_PAN => 'string',

--- a/tests/Gateway/DataSets/OrderTest.php
+++ b/tests/Gateway/DataSets/OrderTest.php
@@ -29,6 +29,8 @@ class OrderTest extends TestCase
             DataSet::GENERAL_DATA_ORDER_DATA_CUSTOM_RETURN_URL => 'jjj',
             DataSet::GENERAL_DATA_ORDER_DATA_RECURRING_EXPIRY => 'kkk',
             DataSet::GENERAL_DATA_ORDER_DATA_RECURRING_FREQUENCY => 'lll',
+            DataSet::GENERAL_DATA_ORDER_DATA_MITS_EXPECTED => true,
+            DataSet::GENERAL_DATA_ORDER_DATA_VARIABLE_AMOUNT_RECURRING => true,
         ];
 
         $order = new Order();
@@ -43,6 +45,8 @@ class OrderTest extends TestCase
             ->setCustomReturnUrl('jjj')
             ->setRecurringExpiry('kkk')
             ->setRecurringFrequency('lll')
+            ->setMitsExpected()
+            ->setVariableAmountRecurring()
             ->getRaw();
 
         $this->assertEquals($expected, $raw);


### PR DESCRIPTION
 - mits-expected: must be set to true for UCOF initialization if any subsequent MIT transactions are supposed to be
 - variable-amount-recurring: must be set to true for initial recurring transaction if amount will not be fixed for subsequent transactions